### PR TITLE
fix/allow querystring

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ const Loadable = require('react-loadable');
 const getBundles = require('react-loadable/webpack').getBundles;
 
 const LRU = require('lru-cache');
+const he = require('he');
 
 const cacheTime = 60; // In seconds
 
@@ -29,7 +30,9 @@ const cache = LRU({ max: 500, maxAge: 1000 * cacheTime });
 // Create a promise of the match function from react-routes. We have this step so we can use **yield** later
 async function render (context, appState, options) {
 
-    let requestUrl = context.req.url.replace(/[^-a-zA-Z/0-9]/gm, '-');
+    let decodedRequestUrl = decodeURIComponent(context.req.url);
+    decodedRequestUrl = he.decode(decodedRequestUrl);
+    let requestUrl = decodedRequestUrl.replace(/[^-a-zA-Z/0-9)=\?&%\s]/gm, '');
     requestUrl = encodeURI(requestUrl);
 
     let modules = [];

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ async function render (context, appState, options) {
 
     let decodedRequestUrl = decodeURIComponent(context.req.url);
     decodedRequestUrl = he.decode(decodedRequestUrl);
-    let requestUrl = decodedRequestUrl.replace(/[^-a-zA-Z/0-9)=\?&%\s]/gm, '');
+    let requestUrl = decodedRequestUrl.replace(/[^-a-zA-Z/0-9)=\?&_%\s]/gm, '');
     requestUrl = encodeURI(requestUrl);
 
     let modules = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rawb-react-ssr",
-    "version": "0.8.6",
+    "version": "0.8.7",
     "description": "Frontend Service Side Render for React and RAWB",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rawb-react-ssr",
-    "version": "0.8.5",
+    "version": "0.8.6",
     "description": "Frontend Service Side Render for React and RAWB",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     },
     "dependencies": {
         "lru-cache": "4.1.3",
+        "he": "1.2.0",
         "redux": "3.4.0",
         "redux-thunk": "2.0.1",
         "react-redux": "^5.0.0",


### PR DESCRIPTION
# Reason for change
Need to be able to receive and pass on a querystring. This was until now cleaned as all symbols not numbers or letters where replaced by '-'

# Changes
* Allowed for more symbols to be left in the request url. ('?&=%_')
* Cleaned the string from html entities to protect against further insecurities caused by allowing these symbols.

# Testing
* Go to a cision feed page.
* Select a query from the dropdowns.
* Reload the page and carefully watch that we do not get a 404 page for a short while before the content is loaded. 
* Try adding for example: &copy;  , to the end of the querystring and make sure that this does not break the cision module and that it filters correctly. 